### PR TITLE
Move o react e o react-dom para as peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "printWidth": 120
   },
   "author": "Lucas Junior Dias",
-  "peerDependencies": {},
+  "peerDependencies": {
+    "react": "^16.0.0",
+    "react-dom": "^16.13.1"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.21.0",
@@ -52,8 +55,6 @@
   },
   "dependencies": {
     "i18next": "^19.7.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.13.1",
     "react-i18next": "^11.7.1",
     "react-icons": "^3.9.0",
     "styled-components": "^5.1.1"


### PR DESCRIPTION
Essa pequena alteração vai evitar o seguinte erro ao utilizar versões mais recentes do react:
```
Error: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem
```