### PR TITLE
HLS support is finally included 

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,11 +2,9 @@ import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import typescript from "@rollup/plugin-typescript";
 import dts from "rollup-plugin-dts";
-
-const packageJson = require("./package.json");
-
 import { terser } from "rollup-plugin-terser";
-import peerDepsExternal from 'rollup-plugin-peer-deps-external';
+import peerDepsExternal from "rollup-plugin-peer-deps-external";
+const packageJson = require("./package.json");
 
 export default [
   {
@@ -23,6 +21,8 @@ export default [
         sourcemap: true,
       },
     ],
+    // Mark dependencies like react, react-dom, and hls.js as external
+    external: ["react", "react-dom", "hls.js"],
     plugins: [
       peerDepsExternal(),
       resolve(),

--- a/src/components/ReactNetflixPlayer/index.tsx
+++ b/src/components/ReactNetflixPlayer/index.tsx
@@ -1,3 +1,4 @@
+import Hls from 'hls.js';
 import React, { useEffect, useState, useRef, SyntheticEvent } from 'react';
 import i18n from 'i18next';
 import { useTranslation, initReactI18next } from 'react-i18next';
@@ -506,6 +507,35 @@ export default function ReactNetflixPlayer({
       setPlaying(autoPlay);
     }
   }, [src]);
+  
+  useEffect(() => {
+  const video = videoComponent.current;
+  if (!video || !src) return;
+
+  // If it's HLS (.m3u8)
+  if (src.endsWith('.m3u8')) {
+    if (Hls.isSupported()) {
+      const hls = new Hls();
+      hls.loadSource(src);
+      hls.attachMedia(video);
+
+      hls.on(Hls.Events.ERROR, function (event, data) {
+        console.error('HLS.js error:', data);
+      });
+
+      return () => {
+        hls.destroy();
+      };
+    } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+      // Safari native support
+      video.src = src;
+    }
+  } else {
+    // Fallback for regular .mp4 or other types
+    video.src = src;
+  }
+}, [src]);
+
 
   useEffect(() => {
     document.addEventListener('keydown', getKeyBoardInteration, false);
@@ -614,7 +644,6 @@ export default function ReactNetflixPlayer({
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <video
         ref={videoComponent}
-        src={src}
         controls={false}
         onCanPlay={() => startVideo()}
         onTimeUpdate={timeUpdate}


### PR DESCRIPTION
include hls support , player can play m3u8 video files as well , in order to do that make sure you run `npm install hls.js` on your machine before importing @Lucasmg37 